### PR TITLE
Cjj overlay

### DIFF
--- a/python/combine.py
+++ b/python/combine.py
@@ -225,11 +225,11 @@ def stats_for_repeated_cycles(adf, variable='total_flow') :
     '''
     nstats = 7
     di_series = adf['diindex']
-    length = di_series.max() - di_series.min()+1
+    length = di_series.max() - di_series.min()
     local_stats_array = np.zeros((int(length), nstats),dtype='float64')
     di_arr = np.arange(di_series.min(), di_series.max())
     for i in di_arr:
-        this_series = adf.loc[adf.diindex==1, variable]
+        this_series = adf.loc[adf.diindex==i, variable]
         # Do some sanity checking here that diindex and dtc track perfectly
         dtcmin = adf[adf.diindex==i]['dtc'].min()
         dtcmax = adf[adf.diindex==i]['dtc'].max()
@@ -538,10 +538,10 @@ def process_run(meta, objname, input_mvm, fullpath_rwa, fullpath_dta, columns_rw
   ##################################
   # Make data frames for statistics on overlayed cycles
   ##################################
-  dftmp = df[ (df['start'] >= start_times[ 4 ] ) & ( df['start'] < start_times[ min ([35,len(start_times)-1] )  ])] 
+  dftmp = df[ (df['start'] >= start_times[ 4 ] ) & ( df['start'] < start_times[ min ([35,len(start_times)-2] )  ])] 
   stats_total_vol = stats_for_repeated_cycles(dftmp, 'total_vol')
   stats_total_flow = stats_for_repeated_cycles(dftmp, 'total_flow')
-  stats_airway_pressure = stats_for_repeated_cycles(dftmp, 'total_flow')
+  stats_airway_pressure = stats_for_repeated_cycles(dftmp, 'airway_pressure')
   
   
   ##################################
@@ -549,10 +549,11 @@ def process_run(meta, objname, input_mvm, fullpath_rwa, fullpath_dta, columns_rw
   ##################################
   if save:
     df.to_hdf(f'{objname}.sim.h5', key='simulator')
+    dftmp.to_hdf(f'{objname}.sim.h5', key='simulator_truncated')
     dfhd.to_hdf(f'{objname}.mvm.h5', key='MVM')
     stats_total_vol.to_hdf(f'{objname}.sim.h5', key='stats_total_vol')
     stats_total_flow.to_hdf(f'{objname}.sim.h5', key='stats_total_flow')
-    stats_airway_pressure.to_hdf(f'{objname}.sim.h5', key='airway_pressure')
+    stats_airway_pressure.to_hdf(f'{objname}.sim.h5', key='stats_airway_pressure')
     
   if args.plot :
     ####################################################
@@ -612,7 +613,7 @@ def process_run(meta, objname, input_mvm, fullpath_rwa, fullpath_dta, columns_rw
       '''summary plots of measured quantities and avg wfs'''
       ####################################################
       plot_summary_canvases (df, dfhd, meta, objname, output_directory, start_times, colors, measured_peeps, measured_plateaus, real_plateaus, measured_peaks, measured_volumes, real_tidal_volumes)
-      #plot_overlay_canvases ( df, dfhd, meta, objname, output_directory, start_times, colors, stats_total_vol, stats_total_flow, stats_airway_pressure )
+      plot_overlay_canvases ( dftmp, dfhd, meta, objname, output_directory, start_times, colors, stats_total_vol, stats_total_flow, stats_airway_pressure )
       
       filepath = "%s/summary_%s_%s.json" % (output_directory, meta[objname]['Campaign'],objname.replace('.txt', '')) # TODO: make sure it is correct, or will overwrite!
       json.dump( meta[objname], open(filepath , 'w' ) )

--- a/python/combine.py
+++ b/python/combine.py
@@ -550,7 +550,9 @@ def process_run(meta, objname, input_mvm, fullpath_rwa, fullpath_dta, columns_rw
   if save:
     df.to_hdf(f'{objname}.sim.h5', key='simulator')
     dfhd.to_hdf(f'{objname}.mvm.h5', key='MVM')
-
+    stats_total_vol.to_hdf(f'{objname}.sim.h5', key='stats_total_vol')
+    stats_total_flow.to_hdf(f'{objname}.sim.h5', key='stats_total_flow')
+    stats_airway_pressure.to_hdf(f'{objname}.sim.h5', key='airway_pressure')
     
   if args.plot :
     ####################################################
@@ -610,7 +612,7 @@ def process_run(meta, objname, input_mvm, fullpath_rwa, fullpath_dta, columns_rw
       '''summary plots of measured quantities and avg wfs'''
       ####################################################
       plot_summary_canvases (df, dfhd, meta, objname, output_directory, start_times, colors, measured_peeps, measured_plateaus, real_plateaus, measured_peaks, measured_volumes, real_tidal_volumes)
-      plot_overlay_canvases ( df, dfhd, meta, objname, output_directory, start_times, colors, stats_total_vol, stats_total_flow, stats_airway_pressure )
+      #plot_overlay_canvases ( df, dfhd, meta, objname, output_directory, start_times, colors, stats_total_vol, stats_total_flow, stats_airway_pressure )
       
       filepath = "%s/summary_%s_%s.json" % (output_directory, meta[objname]['Campaign'],objname.replace('.txt', '')) # TODO: make sure it is correct, or will overwrite!
       json.dump( meta[objname], open(filepath , 'w' ) )

--- a/python/combine.py
+++ b/python/combine.py
@@ -139,7 +139,7 @@ def get_start_times(df, thr=50, dist=0.1, quantity='out', timecol='dt'):
   ''' Get times where a given quantity starts being above threshold
   times_open = df[ ( df[quantity]>thr ) ][timecol]
   start_times = [ float(times_open.iloc[i]) for i in range(0, len(times_open)-1) if times_open.iloc[i+1]-times_open.iloc[i] > 0.1  or i == 0  ]
-  '''
+'''
   start_times = df[df['out_status'] == 'closing']['dt'].unique()
   return start_times
 
@@ -429,6 +429,7 @@ def process_run(meta, objname, input_mvm, fullpath_rwa, fullpath_dta, columns_rw
   # compute cycle start
   # start_times = get_muscle_start_times(df) # based on muscle pressure
   start_times    = get_start_times(dfhd) # based on PV2
+  #  start_times    = get_start_times(df, thr=8, quantity='total_flow', timecol='dt') 
 
   if ignore_sim :
     if args.plot :

--- a/python/combine_plot_summary_canvases.py
+++ b/python/combine_plot_summary_canvases.py
@@ -141,70 +141,48 @@ def plot_summary_canvases (df, dfhd, meta, objname, output_directory, start_time
     figs.savefig(figpath)
 
 
-'''
-def plot_overlay_canvases (df, dfhd, meta, objname, output_directory, start_times, colors, stats_total_vol, stats_total_flow, stats_airway_pressure ) :
 
-  for i in range (len(meta)) :
+def plot_overlay_canvases (dftmp, dfhd, meta, objname, output_directory, start_times, colors, stats_total_vol, stats_total_flow, stats_airway_pressure ) :
 
-    ####################################################
-    ### plot the avg wfs
-    ####################################################
-    local_objname = "%s_%i"% ( objname[:-2] , i )
+    figoverlay, axoverlay = plt.subplots(6)
+    figoverlay.set_size_inches(7,9)
+    figoverlay.suptitle ("Test n %s Consistency of Cycles"%meta[objname]['test_name'], weight='heavy', fontsize=14)
 
-    PE = meta[local_objname]["Peep"]
-    PI = meta[local_objname]["Pinspiratia"]
-    RR = meta[local_objname]["Rate respiratio"]
-    RT = meta[local_objname]["Resistance"]
-    CM = meta[local_objname]["Compliance"]
+    axoverlay[4].set_ylabel('Total Vol',fontsize=10)
+    axoverlay[4].set_xlim(0,4)
+    dftmp.plot(ax=axoverlay[4], kind='scatter', x='dtc', y='total_vol', color = colors['total_vol'],fontsize=10)
+    axoverlay[5].set_xlabel('Time since start of cycle (s)',fontsize=14)
+    axoverlay[5].set_xlim(0,4)
+    axoverlay[5].set_ylim(-0.2,0.2)
+#    axoverlay[5].legend(loc='upper right', title_fontsize=10, fontsize=10, title='Frac diff from median')
+    stats_total_vol['max_minus_median']=  (stats_total_vol['max'] - stats_total_vol['median'])/stats_total_vol['median']
+    stats_total_vol.plot(ax=axoverlay[5], kind='line', x='dtc', y='max_minus_median', label='_a', color = colors['total_vol'], linewidth=1,fontsize=10)
+    stats_total_vol['min_minus_median']=  (stats_total_vol['min'] - stats_total_vol['median'])/stats_total_vol['median']
+    stats_total_vol.plot(ax=axoverlay[5], kind='line', x='dtc', y='min_minus_median', label='_b', color = colors['total_vol'], linewidth=1)
 
-    fig2, ax2 = plt.subplots()
-    #make a subset dataframe for simulator
-    # This is hardcoded - should it be?
-    dftmp = df[ (df['start'] >= start_times[ 4 ] ) & ( df['start'] < start_times[ min ([35,len(start_times)-1] )  ])]
-    #dftmp['dtc'] = df['dt'] - df['start']  #HTJI Done in the main program
-
-    #make a subset dataframe for ventilator
-    first_time_bin  = dftmp['dt'].iloc[0]
-    last_time_bin   = dftmp['dt'].iloc[len(dftmp)-1]
-    dfvent = dfhd[ (dfhd['dt']>first_time_bin) & (dfhd['dt']<last_time_bin) ]
-    dfvent['dtc'] = dfvent['dt'] - dfvent['start']
-    dfvent = dfvent.sort_values('dtc')
-
-    dftmp.loc[:, 'total_vol'] = dftmp['total_vol'] - dftmp['total_vol'].min()
-
-    dftmp.plot(ax=ax2, x='dtc', y='total_vol',         label='SIM tidal volume       [cl]', c=colors['total_vol'] ,          marker='o', markersize=0.3, linewidth=0)
-    dftmp.plot(ax=ax2, x='dtc', y='total_flow',        label='SIM flux            [l/min]', c=colors['total_flow'],          marker='o', markersize=0.3, linewidth=0)
-    dftmp.plot(ax=ax2, x='dtc', y='airway_pressure',   label='SIM airway pressure [cmH2O]', c=colors['sim_airway_pressure'], marker='o', markersize=0.3, linewidth=0)
-
-    dfvent.plot(ax=ax2,  x='dtc', y='tidal_volume',    label='MVM tidal volume       [cl]', c=colors['tidal_volume'],         marker='o', markersize=0.3, linewidth=0.2)
-    dfvent.plot(ax=ax2,  x='dtc', y='display_flux',    label='MVM flux            [l/min]', c=colors['flux'],                 marker='o', markersize=0.3, linewidth=0.2)
-    dfvent.plot(ax=ax2,  x='dtc', y='airway_pressure', label='MVM airway pressure [cmH2O]', c=colors['vent_airway_pressure'], marker='o', markersize=0.3, linewidth=0.2)
-
-    
-    ymin, ymax = ax2.get_ylim()
-    ax2.set_ylim(ymin*1.4, ymax*1.5)
-    ax2.legend(loc='upper center', ncol=2)
-    title1="R = %i [cmH2O/l/s]         C = %2.1f [ml/cmH20]        PEEP = %s [cmH20]"%(RT,CM,PE )
-    title2="Inspiration Pressure = %s [cmH20]       Frequency = %s [breath/min]"%(PI,RR)
-
-    ax2.set_xlabel("Time [s]")
-
-    xmin, xmax = ax2.get_xlim()
-    ymin, ymax = ax2.get_ylim()
-    ax2.text((xmax-xmin)/2.+xmin, 0.08*(ymax-ymin) + ymin,   title2, verticalalignment='bottom', horizontalalignment='center', color='#7697c4')
-    ax2.text((xmax-xmin)/2.+xmin, 0.026*(ymax-ymin) + ymin,  title1, verticalalignment='bottom', horizontalalignment='center', color='#7697c4')
-    nom_pressure = float(meta[local_objname]["Pinspiratia"])
-    rect = patches.Rectangle((xmin,nom_pressure-2),xmax-xmin,4,edgecolor='None',facecolor='green', alpha=0.2)
-    ax2.add_patch(rect)
-
-    nom_peep = float(meta[local_objname]["Peep"])
-    rect = patches.Rectangle((xmin,nom_peep-0.1),xmax-xmin,0.5,edgecolor='None',facecolor='grey', alpha=0.3)
-    ax2.add_patch(rect)
-
-    ax2.set_title ("Test n %s"%meta[objname]['test_name'])
-    figpath = "%s/%s_avg_%s.png" % (output_directory, meta[objname]['Campaign'] , objname.replace('.txt', '')) # TODO: make sure it is correct, or will overwrite!
-    print(f'Saving figure to {figpath}')
-    fig2.savefig(figpath)
+    #
+    axoverlay[0].set_ylabel('Total Flow',fontsize=10)
+    axoverlay[0].set_xlim(0,4)
+    dftmp.plot(ax=axoverlay[0], kind='scatter', x='dtc', y='total_flow', color = colors['total_flow'],fontsize=10)
+    axoverlay[1].set_xlim(0,4)
+    axoverlay[1].set_ylim(-0.2,0.2)
+    stats_total_flow['max_minus_median']=  (stats_total_flow['max'] - stats_total_flow['median'])/stats_total_flow['median']
+    stats_total_flow.plot(ax=axoverlay[1], kind='line', x='dtc', y='max_minus_median', label='_a',color = colors['total_flow'], linewidth=1,fontsize=10)
+    stats_total_flow['min_minus_median']=  (stats_total_flow['min'] - stats_total_flow['median'])/stats_total_flow['median']
+    stats_total_flow.plot(ax=axoverlay[1], kind='line', x='dtc', y='min_minus_median', label='_b',color = colors['total_flow'], linewidth=1)
+#
+    axoverlay[2].set_ylabel('Pressure',fontsize=10)
+    axoverlay[2].set_xlim(0,4)
+    dftmp.plot(ax=axoverlay[2], kind='scatter', x='dtc', y='airway_pressure', color = colors['pressure'],fontsize=10)
+    axoverlay[3].set_xlim(0,4)
+    axoverlay[3].set_ylim(-0.2,0.2)
+    stats_airway_pressure['max_minus_median']=  (stats_airway_pressure['max'] - stats_airway_pressure['median'])/stats_airway_pressure['median']
+    stats_airway_pressure.plot(ax=axoverlay[3], kind='line', x='dtc', y='max_minus_median', label='_a',color = colors['pressure'], linewidth=1,fontsize=10)
+    stats_airway_pressure['min_minus_median']=  (stats_airway_pressure['min'] - stats_airway_pressure['median'])/stats_airway_pressure['median']
+    stats_airway_pressure.plot(ax=axoverlay[3], kind='line', x='dtc', y='min_minus_median', label='_b', color = colors['pressure'], linewidth=1)
 
 
-'''
+
+    figpath = "%s/%s_overlay_%s.png" % (output_directory, meta[objname]['Campaign'], objname.replace('.txt', '')) # TODO: make sure it is correct, or will overwrite!
+    figoverlay.savefig(figpath)
+

--- a/python/combine_plot_summary_canvases.py
+++ b/python/combine_plot_summary_canvases.py
@@ -27,7 +27,6 @@ def plot_summary_canvases (df, dfhd, meta, objname, output_directory, start_time
 
 
     
-    '''
     fig2, ax2 = plt.subplots()
     #make a subset dataframe for simulator
     # This is hardcoded - should it be?
@@ -75,7 +74,6 @@ def plot_summary_canvases (df, dfhd, meta, objname, output_directory, start_time
     figpath = "%s/%s_avg_%s.png" % (output_directory, meta[objname]['Campaign'] , objname.replace('.txt', '')) # TODO: make sure it is correct, or will overwrite!
     print(f'Saving figure to {figpath}')
     fig2.savefig(figpath)
-    '''
     
     mean_peep    =   meta[objname]["mean_peep"]
     mean_plateau =   meta[objname]["mean_plateau"]
@@ -143,12 +141,13 @@ def plot_summary_canvases (df, dfhd, meta, objname, output_directory, start_time
     figs.savefig(figpath)
 
 
+'''
 def plot_overlay_canvases (df, dfhd, meta, objname, output_directory, start_times, colors, stats_total_vol, stats_total_flow, stats_airway_pressure ) :
 
   for i in range (len(meta)) :
 
     ####################################################
-    '''plot the avg wfs'''
+    ### plot the avg wfs
     ####################################################
     local_objname = "%s_%i"% ( objname[:-2] , i )
 
@@ -208,3 +207,4 @@ def plot_overlay_canvases (df, dfhd, meta, objname, output_directory, start_time
     fig2.savefig(figpath)
 
 
+'''

--- a/python/db.py
+++ b/python/db.py
@@ -98,6 +98,7 @@ def read_meta_from_spreadsheet (df, filename) :
       'SimulatorFileName': df["simulator_filename"].iloc[idx] ,
       'Campaign': df["campaign"].iloc[idx] ,
       'MVM_filename' : df["MVM_filename"].iloc[idx],
+#      'MVM_mapping' : df["MVM_mapping"].iloc[idx],  #HTJI
       'test_name' : df["N"].iloc[idx],
       'Tidal Volume' : df["TV"].iloc[idx],
       'leakage' : df["leakage"].iloc[idx],


### PR DESCRIPTION
This file leaves the existing analysis unaffected.

There is a new function which creates dataframes describing the stats over various cycles. ie stats about the persistence plots. These are stored in three dataframes. For this to work I needed to advance the creation of dftmp *and I excluded the last two cycles* not just the last cycle.

If you choose the save option the dftmp and the three new stats dataframes are all written to the sim file. (This is for jupyter work outside of the main program.)

The plot now looks okay. Not great, but good enough for inclusion.