### PR TITLE
Close plt at end of process_run, and add -show option to combine.py

### DIFF
--- a/python/combine.py
+++ b/python/combine.py
@@ -546,6 +546,13 @@ def process_run(meta, objname, input_mvm, fullpath_rwa, fullpath_dta, columns_rw
       filepath = "%s/summary_%s_%s.json" % (output_directory, meta[objname]['Campaign'],objname.replace('.txt', '')) # TODO: make sure it is correct, or will overwrite!
       json.dump( meta[objname], open(filepath , 'w' ) )
 
+    ####################################################
+    '''show then close figures for this run'''
+    ####################################################
+    if args.show:
+      plt.show()
+    plt.close('all')
+
 
 if __name__ == '__main__':
   import argparse
@@ -557,7 +564,8 @@ if __name__ == '__main__':
   parser.add_argument("-d", "--output-directory", type=str, help="name of the output directory for plots", default="plots_iso")
   parser.add_argument("-i", "--ignore_sim", action='store_true',  help="ignore_sim")
   parser.add_argument("-skip", "--skip_files", type=str,  help="skip files", nargs='+', default="")
-  parser.add_argument("-p", "--plot", action='store_true', help="show plots")
+  parser.add_argument("-p", "--plot", action='store_true', help="make and save plots")
+  parser.add_argument("-show", "--show", action='store_true', help="show plots")
   parser.add_argument("-s", "--save", action='store_true', help="save HDF")
   parser.add_argument("-f", "--filename", type=str, help="single file to be processed", default='.')
   parser.add_argument("-c", "--campaign", type=str, help="single campaign to be processed", default="")
@@ -657,10 +665,3 @@ if __name__ == '__main__':
 
     # run
     process_run(meta, objname=objname, input_mvm=fname, fullpath_rwa=fullpath_rwa, fullpath_dta=fullpath_dta, columns_rwa=columns_rwa, columns_dta=columns_dta, save=args.save, manual_offset=args.offset,  ignore_sim=args.ignore_sim, mvm_sep=args.mvm_sep, output_directory=args.output_directory, mvm_columns=args.mvm_col, mvm_json=args.json)
-
-  if args.plot:
-    if ( len (filenames) < 2 ) :
-      plt.show()
-    else :
-      answer = input("plot all the files? (return: yes, Ctrl-D: no)")
-      plt.show()


### PR DESCRIPTION
The prompt at the end of combine.py is replaced by a command-line argument "-show".  It is false by default.  This is important for batch processing of data.

Also, close plt at the end of every call to process_run, to ensure we don't run out of memory.
