### PR TITLE
fix bug in volume accuracy band

### DIFF
--- a/python/mvmconstants.py
+++ b/python/mvmconstants.py
@@ -11,7 +11,7 @@ class Ventilator:
   maximum_linearity_error_peep = 0.04    # B/100 for PEEP
   maximum_bias_error_pinsp = 2           # A in cmH2O
   maximum_linearity_error_pinsp = 0.04   # B/100 for Pinsp
-  maximum_bias_error_volume = 40         # A in ml
+  maximum_bias_error_volume = 4          # A in ml
   maximum_linearity_error_volume = 0.15  # B/100 for tidal volume
 
   ## There probably exist other ventilator constants of interest
@@ -30,4 +30,4 @@ class Ventilator:
     self.maximum_linearity_error_volume = B_vol    # B/100 for tidal volume
 
 
-MVM = Ventilator(2, 0.04, 2, 0.04, 40, 0.15)
+MVM = Ventilator(2, 0.04, 2, 0.04, 4, 0.15)


### PR DESCRIPTION
It looks like the MHRA document quoted in mvmconstants.py reports 4 ml as maximum bias error on the volume, while the code here writes 40 ml