### PR TITLE
Set parameters validation as warning

### DIFF
--- a/python/combine.py
+++ b/python/combine.py
@@ -777,6 +777,7 @@ if __name__ == '__main__':
     for input in args.input :
       meta  = read_meta_from_spreadsheet_json (input)
       objname = list ( meta.keys()) [0]
+      validate_meta(meta[objname])
       meta[objname]['SiteName'] = sitename
       basedir = '/'.join ( input.split('/')[0:-1] )
       fullpath_rwa = "%s/%s"%( basedir,meta[objname]['RwaFileName'] )
@@ -848,6 +849,9 @@ if __name__ == '__main__':
         if args.campaign not in fname:
           print(f'    ... not in selected campaign {args.campaign}')
           continue
+
+      # validate metadata for this run
+      validate_meta(meta[objname])
 
       # determine RWA and DTA data locations
       fullpath_rwa = f'{input}/{meta[objname]["Campaign"]}/{meta[objname]["SimulatorFileName"]}'

--- a/python/db.py
+++ b/python/db.py
@@ -109,7 +109,6 @@ def read_meta_from_spreadsheet (df, filename) :
       'leakage' : float ( df["leakage"].iloc[idx] ),
       'cycle_index' : int ( df["cycle_index"].iloc[idx]),
     }
-    validate_meta(meta[key])
   return meta
 
 
@@ -144,7 +143,6 @@ def read_meta_from_spreadsheet_json (filename) :
     'cycle_index' : int ( mydict['cycle_index'] ),
   }
   print (meta)
-  validate_meta(meta[key])
   return meta
 
 

--- a/python/db.py
+++ b/python/db.py
@@ -6,6 +6,7 @@ from google.auth.transport.requests import Request
 import pickle
 import os
 import pandas as pd
+import logging as log
 import json
 
 from mvmconstants import *
@@ -169,7 +170,7 @@ def validate_meta(meta_value):
   else:
     print("Test parameters from spreadsheet versus standard test:")
     this_test.print_comparison(StandardTests[this_test_name])
-    raise AssertionError(f"Metadata validation FAILED for test {this_test_name}, please see comparison above")
+    log.warning(f"Metadata validation FAILED for test {this_test_name}, please see comparison above")
 
 
 if __name__ == "__main__" :

--- a/python/mvmconstants.py
+++ b/python/mvmconstants.py
@@ -60,7 +60,7 @@ class PressureTest:
     self.O2 = O2
 
   def __eq__(self, other):
-    epsilon = 1e-3
+    epsilon = 5e-3
     return (
       abs(self.TV - other.TV) < epsilon and
       abs(self.C - other.C) < epsilon and

--- a/python/mvmconstants.py
+++ b/python/mvmconstants.py
@@ -60,7 +60,7 @@ class PressureTest:
     self.O2 = O2
 
   def __eq__(self, other):
-    epsilon = 1e-6
+    epsilon = 1e-3
     return (
       abs(self.TV - other.TV) < epsilon and
       abs(self.C - other.C) < epsilon and


### PR DESCRIPTION
Raising an AssertionError turned out to be too annoying - decreased level to a warning for failure in validation of the set parameters

I have also raised epsilon to 5e-3.  We're worried about discrepancies above this level, and below are acceptable rounding errors from spreadsheet

Moved validate_meta into combine.py, so it doesn't get run for skipped runs
