### PR TITLE
Separate plotting from process_run

### DIFF
--- a/python/combine.py
+++ b/python/combine.py
@@ -850,7 +850,7 @@ if __name__ == '__main__':
       conf["fullpath_rwa"] = fullpath_rwa
       conf["fullpath_dta"] = fullpath_dta
       data = process_run(conf=conf, ignore_sim=args.ignore_sim, auto_sync_debug=args.automatic_sync)
-      plot_run(data, config, args)
+      plot_run(data, conf, args)
 
 
   else :
@@ -938,4 +938,4 @@ if __name__ == '__main__':
       conf["fullpath_rwa"] = fullpath_rwa
       conf["fullpath_dta"] = fullpath_dta
       data = process_run(conf=conf, ignore_sim=args.ignore_sim, auto_sync_debug=args.automatic_sync)
-      plot_run(data, config, args)
+      plot_run(data, conf, args)

--- a/python/combine.py
+++ b/python/combine.py
@@ -794,9 +794,9 @@ if __name__ == '__main__':
   #FIXME in spreadsheet: workaround for Elemaster data, assuming no tab name from another site contains 'ISO'
   if 'ISO' in sitename:
     sitename = "Elemaster"
-  print(f'Analyzing data from {sitename}')
   if not sitename:
     sitename = "UnknownSite"
+  print(f'Analyzing data from {sitename}')
 
   filenames = []  #if the main argument is a json, skip the direct spreadsheet reader
   if args.input[0].split('.')[-1]== 'json' :

--- a/python/combine.py
+++ b/python/combine.py
@@ -636,7 +636,7 @@ def process_run(conf, ignore_sim, auto_sync_debug):
       "measured_peaks" : measured_peaks,
       "measured_plateaus" : measured_plateaus,
       "real_tidal_volumes" : real_tidal_volumes,
-      "real_plateaus:" real_plateaus,
+      "real_plateaus" : real_plateaus,
       "stats_total_vol" : stats_total_vol,
       "stats_total_flow" : stats_total_flow,
       "stats_airway_pressure" : stats_airway_pressure

--- a/python/combine.py
+++ b/python/combine.py
@@ -819,7 +819,7 @@ if __name__ == '__main__':
       "offset" : args.offset,
       "pressure_offset" : args.pressure_offset,
       "mvm_sep" : args.mvm_sep,
-      "mvm_col" : mvm_col
+      "mvm_col" : args.mvm_col
       }
 
   # determine site name from spreadsheet tab name

--- a/python/combine.py
+++ b/python/combine.py
@@ -21,18 +21,18 @@ from combine_plot_mvm_only_canvases import *
 # py combine.py ../Data -p -f VENTILATOR_12042020_CONTROLLED_FR20_PEEP5_PINSP30_C50_R5_RATIO050.txt  --mvm-col='mvm_col_arduino' -d plots_iso_12Apr
 
 def add_timestamp(df, timecol='dt'):
-  ''' add timestamp column assuming constant sampling in time '''
+  ''' Add timestamp column assuming constant sampling in time '''
   df['timestamp'] = np.linspace( df.iloc[0,:][timecol] ,  df.iloc[-1,:][timecol] , len(df) )
   ''' Based on discussions at 2020-04-26 analysis call, check to see of there really is a
   problem with the time stamps and to see how big the shift is. CJJ - 2020-04-26'''
   df['dtcheck'] = df['timestamp']-df['dt']
   max_time_off = df['dtcheck'].max()
   min_time_off = df['dtcheck'].min()
-  print("The maximum  shifts in timestamp are... ", max_time_off, min_time_off)
+  print("The maximum shifts in timestamp are... ", max_time_off, min_time_off)
   return df
 
 def get_deltat(df, timestampcol='timestamp', timecol='dt'):
-  ''' retrieve sampling time '''
+  ''' Retrieve sampling time '''
   return df[timestampcol].iloc[2] - df[timestampcol].iloc[1]
 
 def correct_sim_df(df):
@@ -74,7 +74,7 @@ def synchronize_first_signals(df, dfhd, threshold_sim, threshold_mvm, diagnostic
     return 0
   mvm_threshold_row = dfhdtmp.iloc[0]
   mvm_time = mvm_threshold_row['dt']
-  print("The auto-calculated synchronization time shift between MVM and simulator is ", (simulator_time - mvm_time))
+  print("The auto-calculated synchronization time shift between MVM and simulator is %.3f seconds"%(simulator_time - mvm_time))
   if diagnostic_plots  :
     dfhd['dtshifted'] = dfhd['dt'] + (simulator_time - mvm_time)
     figdiag, axdiag = plt.subplots(2)

--- a/python/combine.py
+++ b/python/combine.py
@@ -681,7 +681,7 @@ def plot_run(data, conf, args):
   measured_peaks = data["measured_peaks"],
   measured_plateaus = data["measured_plateaus"],
   real_tidal_volumes = data["real_tidal_volumes"],
-  real_plateaus:" real_plateaus"],
+  real_plateaus = data["real_plateaus"],
   stats_total_vol = data["stats_total_vol"],
   stats_total_flow = data["stats_total_flow"],
   stats_airway_pressure = data["stats_airway_pressure"]

--- a/python/combine.py
+++ b/python/combine.py
@@ -669,21 +669,21 @@ def plot_run(data, conf, args):
     return
 
   # keep the following in sync with the dict returned by process_run
-  df = data["sim"],
-  dftmp = data["sim_trunc"],
-  dfhd = data["mvm"],
-  start_times = data["start_times"],
-  reaction_times = data["reaction_times"],
-  respiration_rate = data["respiration_rate"],
-  inspiration_duration = data["inspiration_duration"],
-  measured_peeps = data["measured_peeps"],
-  measured_volumes = data["measured_volumes"],
-  measured_peaks = data["measured_peaks"],
-  measured_plateaus = data["measured_plateaus"],
-  real_tidal_volumes = data["real_tidal_volumes"],
-  real_plateaus = data["real_plateaus"],
-  stats_total_vol = data["stats_total_vol"],
-  stats_total_flow = data["stats_total_flow"],
+  df = data["sim"]
+  dftmp = data["sim_trunc"]
+  dfhd = data["mvm"]
+  start_times = data["start_times"]
+  reaction_times = data["reaction_times"]
+  respiration_rate = data["respiration_rate"]
+  inspiration_duration = data["inspiration_duration"]
+  measured_peeps = data["measured_peeps"]
+  measured_volumes = data["measured_volumes"]
+  measured_peaks = data["measured_peaks"]
+  measured_plateaus = data["measured_plateaus"]
+  real_tidal_volumes = data["real_tidal_volumes"]
+  real_plateaus = data["real_plateaus"]
+  stats_total_vol = data["stats_total_vol"]
+  stats_total_flow = data["stats_total_flow"]
   stats_airway_pressure = data["stats_airway_pressure"]
 
   ##################################

--- a/python/combine.py
+++ b/python/combine.py
@@ -427,7 +427,7 @@ def add_run_info(df, dist=25):
   df['run'] = df['run']*10
 
 
-def process_run(conf, ignore_sim, auto_sync_debug):
+def process_run(conf, ignore_sim=False, auto_sync_debug=False):
   columns_rwa = ['dt',
     'airway_pressure',
     'muscle_pressure',

--- a/python/combine.py
+++ b/python/combine.py
@@ -428,46 +428,13 @@ def add_run_info(df, dist=25):
 
 
 def process_run(conf, ignore_sim=False, auto_sync_debug=False):
-  columns_rwa = ['dt',
-    'airway_pressure',
-    'muscle_pressure',
-    'tracheal_pressure',
-    'chamber1_vol',
-    'chamber2_vol',
-    'total_vol',
-    'chamber1_pressure',
-    'chamber2_pressure',
-    'breath_fileno',
-    'aux1',
-    'aux2',
-    'oxygen'
-  ]
-  columns_dta = [#'dt',
-    'breath_no',
-    'compressed_vol',
-    'airway_pressure',
-    'muscle_pressure',
-    'total_vol',
-    'total_flow',
-    'chamber1_pressure',
-    'chamber2_pressure',
-    'chamber1_vol',
-    'chamber2_vol',
-    'chamber1_flow',
-    'chamber2_flow',
-    'tracheal_pressure',
-    'ventilator_vol',
-    'ventilator_flow',
-    'ventilator_pressure',
-  ]
-
   objname = conf["objname"]
   meta = conf["meta"]
 
   # retrieve simulator data
 
   if not ignore_sim:
-    df = get_simulator_df(conf["fullpath_rwa"], conf["fullpath_dta"], columns_rwa, columns_dta)
+    df = get_simulator_df(conf["fullpath_rwa"], conf["fullpath_dta"])
   else:
     print ("I am ignoring the simulator")
 
@@ -641,7 +608,7 @@ def process_run(conf, ignore_sim=False, auto_sync_debug=False):
       "stats_total_flow" : stats_total_flow,
       "stats_airway_pressure" : stats_airway_pressure
       }
-      
+
 
 
 def plot_run(data, conf, args):

--- a/python/mvmio.py
+++ b/python/mvmio.py
@@ -93,7 +93,7 @@ def get_raw_df(fname, columns, columns_to_deriv, timecol='dt'):
     df[f'deriv_{column}'] = df[column].diff() / df[timecol].diff() * 60. # TODO
   return df
 
-def get_simulator_df(fullpath_rwa, fullpath_dta):
+def get_simulator_df(fullpath_rwa, fullpath_dta, columns_rwa=columns_rwa, columns_dta=columns_dta):
   df_rwa = get_raw_df(fullpath_rwa, columns=columns_rwa, columns_to_deriv=['total_vol'])
   df_dta = get_raw_df(fullpath_dta, columns=columns_dta, columns_to_deriv=[])
   df0 = df_dta.join(df_rwa['dt'])

--- a/python/mvmio.py
+++ b/python/mvmio.py
@@ -2,6 +2,40 @@ import numpy as np
 import pandas as pd
 import json
 
+columns_rwa = ['dt',
+  'airway_pressure',
+  'muscle_pressure',
+  'tracheal_pressure',
+  'chamber1_vol',
+  'chamber2_vol',
+  'total_vol',
+  'chamber1_pressure',
+  'chamber2_pressure',
+  'breath_fileno',
+  'aux1',
+  'aux2',
+  'oxygen'
+]
+
+columns_dta = [#'dt',
+  'breath_no',
+  'compressed_vol',
+  'airway_pressure',
+  'muscle_pressure',
+  'total_vol',
+  'total_flow',
+  'chamber1_pressure',
+  'chamber2_pressure',
+  'chamber1_vol',
+  'chamber2_vol',
+  'chamber1_flow',
+  'chamber2_flow',
+  'tracheal_pressure',
+  'ventilator_vol',
+  'ventilator_flow',
+  'ventilator_pressure',
+]
+
 mapping = {
   'default': [
     'date',
@@ -27,7 +61,6 @@ mapping = {
     'volume',
     'service_2'
   ],
-
   'mvm_col_no_time' : [
     'pressure_pv1' ,
     'airway_pressure',
@@ -60,7 +93,7 @@ def get_raw_df(fname, columns, columns_to_deriv, timecol='dt'):
     df[f'deriv_{column}'] = df[column].diff() / df[timecol].diff() * 60. # TODO
   return df
 
-def get_simulator_df(fullpath_rwa, fullpath_dta, columns_rwa, columns_dta):
+def get_simulator_df(fullpath_rwa, fullpath_dta):
   df_rwa = get_raw_df(fullpath_rwa, columns=columns_rwa, columns_to_deriv=['total_vol'])
   df_dta = get_raw_df(fullpath_dta, columns=columns_dta, columns_to_deriv=[])
   df0 = df_dta.join(df_rwa['dt'])

--- a/python/mvmio.py
+++ b/python/mvmio.py
@@ -93,9 +93,9 @@ def get_raw_df(fname, columns, columns_to_deriv, timecol='dt'):
     df[f'deriv_{column}'] = df[column].diff() / df[timecol].diff() * 60. # TODO
   return df
 
-def get_simulator_df(fullpath_rwa, fullpath_dta, columns_rwa=columns_rwa, columns_dta=columns_dta):
-  df_rwa = get_raw_df(fullpath_rwa, columns=columns_rwa, columns_to_deriv=['total_vol'])
-  df_dta = get_raw_df(fullpath_dta, columns=columns_dta, columns_to_deriv=[])
+def get_simulator_df(fullpath_rwa, fullpath_dta, df_columns_rwa=columns_rwa, df_columns_dta=columns_dta):
+  df_rwa = get_raw_df(fullpath_rwa, columns=df_columns_rwa, columns_to_deriv=['total_vol'])
+  df_dta = get_raw_df(fullpath_dta, columns=df_columns_dta, columns_to_deriv=[])
   df0 = df_dta.join(df_rwa['dt'])
   df_rwa['oxygen'] = df_rwa['oxygen']  /  df_rwa['airway_pressure']
   df  = df0.join(df_rwa['oxygen'] )


### PR DESCRIPTION
I've separated plotting from process_run into a separate function plot_run. I'm passing all data inside a dictionary to avoid millions of calling parameters. In order to avoid renaming everything, I'm only creating the dict inside the return statement, and unpacking it right at the beginning of plot_run. It's a bit ugly, but does the job.
Furthermore, I've replaced the args parameter in process_run with an ordinary dictionary that contains other parameters as well. Otherwise whenever process_run is used one would have to create the exact same argparse Namespace to properly call it. I have not done this for plot_run, as I won't need it for the comparison. I'm however happy to do so if people think it would be useful.
I haven't yet moved process_run and plot_run to separate source files in order to avoid nasty merge conflicts. Again I'm happy to do so if useful.