### PR TITLE
Revert "remove the dt linspace (use dt read from the MVM output) and substitu…"

### DIFF
--- a/python/combine.py
+++ b/python/combine.py
@@ -22,7 +22,7 @@ from combine_plot_mvm_only_canvases import *
 
 def add_timestamp(df, timecol='dt'):
   ''' Add timestamp column assuming constant sampling in time '''
-  df['timestamp'] = df['dt'] #np.linspace( df.iloc[0,:][timecol] ,  df.iloc[-1,:][timecol] , len(df) )
+  df['timestamp'] = np.linspace( df.iloc[0,:][timecol] ,  df.iloc[-1,:][timecol] , len(df) )
   ''' Based on discussions at 2020-04-26 analysis call, check to see of there really is a
   problem with the time stamps and to see how big the shift is. CJJ - 2020-04-26'''
   df['dtcheck'] = df['timestamp']-df['dt']
@@ -318,8 +318,6 @@ def measure_clinical_values(df, start_times):
   ''' Compute tidal volume and other clinical quantities for MVM data '''
   # TODO: "tolerances", i.e. pre-t0 and post-t1, are currently hardcoded
   deltaT = get_deltat(df)
-  #substitute the fixed deltaT with sample-dependent dt after removal of linspace
-  df['flux_x_dt']  = df['flux'] * df['dt'].diff()
 
   # determine inspiration end times
   inspiration_end_times   = df[df['out_status'] == 'opening']['dt'].unique()
@@ -357,11 +355,11 @@ def measure_clinical_values(df, start_times):
 
     df.loc[this_inspiration, 'is_inspiration'] = 1
     #measured inspiration
-    df.loc[ ( df.dt >  s ) & ( df.dt < next_inspiration_t ), 'cycle_tidal_volume']     = df[  ( df.dt >  s ) & ( df.dt < end_of_inspiration_t) ]['flux_x_dt'].sum() / 60. * 100
+    df.loc[ ( df.dt >  s ) & ( df.dt < next_inspiration_t+2e-3 ), 'cycle_tidal_volume']     = df[  ( df.dt >  s ) & ( df.dt < end_of_inspiration_t+2e-3 ) ]['flux'].sum() * deltaT/60. * 100
     df.loc[this_inspiration, 'cycle_peak_pressure']    = df[ this_inspiration ]['airway_pressure'].max()
     df.loc[this_inspiration, 'cycle_plateau_pressure'] = df[ this_inspiration &( df.dt > v - 20e-3 ) & ( df.dt < v-10e-3 ) ]['airway_pressure'].mean()
     #not necessarily measured during inspiration
-    df.loc[this_inspiration, 'cycle_PEEP']             = df[ ( df.dt > next_inspiration_t - 51e-3 ) & ( df.dt < next_inspiration_t) ] ['airway_pressure'].mean()
+    df.loc[this_inspiration, 'cycle_PEEP']             = df[ ( df.dt > next_inspiration_t - 51e-3 ) & ( df.dt < next_inspiration_t+2e-3 ) ] ['airway_pressure'].mean()
     #print ("cycle_peak_pressure: " , df[ this_inspiration &( df.dt > v - 20e-3 ) & ( df.dt < v-10e-3 ) ]['airway_pressure'].mean() )
 
   respiration_rate     = 60/np.mean(np.gradient (start_times))
@@ -371,11 +369,11 @@ def measure_clinical_values(df, start_times):
 
   for c in df['start'].unique():
     cycle_data = df[df['start']==c]
-    cum = cycle_data['flux_x_dt'].cumsum()
+    cum = cycle_data['flux'].cumsum()
     df.loc[df.start == c, 'tidal_volume'] = cum
 
   # correct flow sum into volume (aka flow integral)
-  df['tidal_volume']   *= 1./60.*100
+  df['tidal_volume']   *= deltaT/60.*100
 
   # set inspiration-only variables to zero outside the inspiratory phase
   df['tidal_volume'] *= df['is_inspiration']
@@ -684,13 +682,10 @@ def plot_run(data, conf, args):
 
     ## For the moment only one test per file is supported here
     ## correct for outliers ?  no, we need to see them
-    ## actually the lines below should select the central 30 cycles
     measured_peeps      = measured_peeps[3:-3]
     measured_plateaus   = measured_plateaus[3:-3]
     measured_peaks      = measured_peaks[3:-3]
     measured_volumes    = measured_volumes[3:-3]
-    real_plateaus       = real_plateaus [3:-3]
-    real_tidal_volumes  = real_tidal_volumes[3:-3]
 
     mean_peep    = np.mean(measured_peeps)
     mean_plateau = np.mean(measured_plateaus)

--- a/python/mvmio.py
+++ b/python/mvmio.py
@@ -50,14 +50,14 @@ mapping = {
   'mvm_col_arduino' : [
     'date',
     'time_arduino',
-    'flux',
+    'flux_2',
     'pressure_pv1',
     'airway_pressure',
     'in',
     'service_1',
     'out',
-    'flux_2',
     'flux_3',
+    'flux',
     'volume',
     'service_2'
   ],


### PR DESCRIPTION
Reverts MechanicalVentilatorMilano/MVMAnalysis#39

This broke `master`, e.g. on the following command (fails on other datasets too), which succeeds on the parent commit a5497a1
```
> python combine.py ${DATADIR_TRIUMF} -json -w -p -d plots_triumf_Apr26 -c "20200426" --db-range-name 'TRIUMF!A2:AF77'
...
Traceback (most recent call last):
  File "combine.py", line 918, in <module>
    plot_run(data, conf, args)
  File "combine.py", line 747, in plot_run
    plot_summary_canvases (df, dfhd, meta, objname, args.output_directory, start_times, colors, args.figure_format, args.web, measured_peeps, measured_plateaus, real_plateaus, measured_peaks, measured_volumes, real_tidal_volumes)
  File "/Users/sviel/GIT/GitHub/MVMAnalysis/python/combine_plot_summary_canvases.py", line 121, in plot_summary_canvases
    axs[1].hist ( measured_plateaus, bins=100, range=_range   )
  File "/Users/sviel/miniconda3/envs/piton3/lib/python3.8/site-packages/matplotlib/__init__.py", line 1565, in inner
    return func(ax, *map(sanitize_sequence, args), **kwargs)
  File "/Users/sviel/miniconda3/envs/piton3/lib/python3.8/site-packages/matplotlib/axes/_axes.py", line 6649, in hist
    m, bins = np.histogram(x[i], bins, weights=w[i], **hist_kwargs)
  File "<__array_function__ internals>", line 5, in histogram
  File "/Users/sviel/miniconda3/envs/piton3/lib/python3.8/site-packages/numpy/lib/histograms.py", line 795, in histogram
    bin_edges, uniform_bins = _get_bin_edges(a, bins, range, weights)
  File "/Users/sviel/miniconda3/envs/piton3/lib/python3.8/site-packages/numpy/lib/histograms.py", line 429, in _get_bin_edges
    first_edge, last_edge = _get_outer_edges(a, range)
  File "/Users/sviel/miniconda3/envs/piton3/lib/python3.8/site-packages/numpy/lib/histograms.py", line 318, in _get_outer_edges
    raise ValueError(
ValueError: supplied range of [nan, nan] is not finite
```