### PR TITLE
CNAF DB Google ID command-line option

### DIFF
--- a/python/combine.py
+++ b/python/combine.py
@@ -900,11 +900,17 @@ if __name__ == '__main__':
   parser.add_argument("-a", "--automatic_sync", action='store_true', help="displays auto-sync diagnostics plot")
   parser.add_argument("--pressure-offset", type=float, help="pressure offset", default='0.')
   parser.add_argument("--figure-format", type=str, help="format for output figures", default='png')
+  parser.add_argument("--cnaf", action='store_true', help="overrides db-google-id to use the CNAF spreadsheet")
   parser.add_argument("--db-google-id", type=str, help="name of the Google spreadsheet ID for metadata", default="1aQjGTREc9e7ScwrTQEqHD2gmRy9LhDiVatWznZJdlqM")
   parser.add_argument("--db-range-name", type=str, help="name of the Google spreadsheet range for metadata", default="20200412 ISO!A2:AZ")
   parser.add_argument("--mvm-sep", type=str, help="separator between datetime and the rest in the MVM filename", default="->")
   parser.add_argument("--mvm-col", type=str, help="columns configuration for MVM acquisition, see mvmio.py", default="mvm_col_arduino")
   args = parser.parse_args()
+
+  if args.cnaf:
+    args.db_google_id = "1AQXgqCKNAuCCDGffi9QU_v_9tOP97qYQNyxx9L6pWRA"
+    print ("Using the CNAF metadata spreadsheet")
+
   conf = {
       "json" : args.json,
       "offset" : args.offset,

--- a/python/combine.py
+++ b/python/combine.py
@@ -913,7 +913,7 @@ if __name__ == '__main__':
   elif args.db_google_id == default_db_google_id:
     print ("Using the default metadata spreadsheet")
   else:
-    print (f"Using the metadata spreadsheet {args.db_google_id}")
+    print (f"Using metadata spreadsheet ID {args.db_google_id}")
 
   conf = {
       "json" : args.json,

--- a/python/combine.py
+++ b/python/combine.py
@@ -901,15 +901,19 @@ if __name__ == '__main__':
   parser.add_argument("--pressure-offset", type=float, help="pressure offset", default='0.')
   parser.add_argument("--figure-format", type=str, help="format for output figures", default='png')
   parser.add_argument("--cnaf", action='store_true', help="overrides db-google-id to use the CNAF spreadsheet")
-  parser.add_argument("--db-google-id", type=str, help="name of the Google spreadsheet ID for metadata", default="1aQjGTREc9e7ScwrTQEqHD2gmRy9LhDiVatWznZJdlqM")
+  parser.add_argument("--db-google-id", type=str, help="name of the Google spreadsheet ID for metadata", default=default_db_google_id)
   parser.add_argument("--db-range-name", type=str, help="name of the Google spreadsheet range for metadata", default="20200412 ISO!A2:AZ")
   parser.add_argument("--mvm-sep", type=str, help="separator between datetime and the rest in the MVM filename", default="->")
   parser.add_argument("--mvm-col", type=str, help="columns configuration for MVM acquisition, see mvmio.py", default="mvm_col_arduino")
   args = parser.parse_args()
 
   if args.cnaf:
-    args.db_google_id = "1AQXgqCKNAuCCDGffi9QU_v_9tOP97qYQNyxx9L6pWRA"
+    args.db_google_id = cnaf_db_google_id
     print ("Using the CNAF metadata spreadsheet")
+  elif args.db_google_id == default_db_google_id:
+    print ("Using the default metadata spreadsheet")
+  else:
+    print (f"Using the metadata spreadsheet {args.db_google_id}")
 
   conf = {
       "json" : args.json,

--- a/python/compare.py
+++ b/python/compare.py
@@ -1,9 +1,10 @@
 import numpy as np
-import db
-import combine as cb
-import mvmio as io
 import matplotlib.pyplot as plt
 import style
+
+from db import *
+import combine as cb
+import mvmio as io
 import combine_plot_utils as cbpu
 
 
@@ -86,8 +87,8 @@ if __name__ == "__main__":
   parser.add_argument("--pressure-offset-2", type=float, help="Pressure offset for second MVM dataset.", default=0.)
   parser.add_argument("--cnaf-1", action='store_true', help="overrides db-google-id to use the CNAF spreadsheet for the first dataset")
   parser.add_argument("--cnaf-2", action='store_true', help="overrides db-google-id to use the CNAF spreadsheet for the second dataset")
-  parser.add_argument("--db-google-id-1", help="First datset metadata spreadsheet ID.", default="1aQjGTREc9e7ScwrTQEqHD2gmRy9LhDiVatWznZJdlqM")
-  parser.add_argument("--db-google-id-2", help="Second datset metadata spreadsheet ID.", default="1aQjGTREc9e7ScwrTQEqHD2gmRy9LhDiVatWznZJdlqM")
+  parser.add_argument("--db-google-id-1", help="First datset metadata spreadsheet ID.", default=default_db_google_id)
+  parser.add_argument("--db-google-id-2", help="Second datset metadata spreadsheet ID.", default=default_db_google_id)
   parser.add_argument("--mvm-sep-1", help="Separator between datetime and the rest in the first MVM file", default="->")
   parser.add_argument("--mvm-sep-2", help="Separator between datetime and the rest in the second MVM file", default="->")
   parser.add_argument("--mvm-col-1", help="Columns configuration for first MVM acquisition, see mvmio.py", default="mvm_col_arduino")
@@ -95,11 +96,20 @@ if __name__ == "__main__":
   args = parser.parse_args()
 
   if args.cnaf_1:
-    args.db_google_id_1 = "1AQXgqCKNAuCCDGffi9QU_v_9tOP97qYQNyxx9L6pWRA"
+    args.db_google_id_1 = cnaf_db_google_id
     print ("Using the CNAF metadata spreadsheet for the first dataset")
+  elif args.db_google_id_1 == default_db_google_id:
+    print ("Using the default metadata spreadsheet for the first dataset")
+  else:
+    print (f"Using the metadata spreadsheet {args.db_google_id_1} for the first dataset")
+
   if args.cnaf_2:
-    args.db_google_id_2 = "1AQXgqCKNAuCCDGffi9QU_v_9tOP97qYQNyxx9L6pWRA"
+    args.db_google_id_2 = cnaf_db_google_id
     print ("Using the CNAF metadata spreadsheet for the second dataset")
+  elif args.db_google_id_2 == default_db_google_id:
+    print ("Using the default metadata spreadsheet for the second dataset")
+  else:
+    print (f"Using the metadata spreadsheet {args.db_google_id_2} for the second dataset")
 
   run_config = [
       {
@@ -137,7 +147,7 @@ if __name__ == "__main__":
     print(f"Meta data {idx}: {rc['db_range_name']} Data location {idx}: {rc['data_location']}")
 
   # read metadata spreadsheet
-  df_spreadsheet = [db.read_online_spreadsheet(rc["db_google_id"], rc["db_range_name"]) for rc in run_config]
+  df_spreadsheet = [read_online_spreadsheet(rc["db_google_id"], rc["db_range_name"]) for rc in run_config]
 
   if args.test_names:
     test_names = [args.test_names]
@@ -180,12 +190,12 @@ if __name__ == "__main__":
         log.warning(f"Test {tn} in {rc['db_range_name']} has emtpy filename. Skipping...")
         success = False
         break
-      rc["meta"] = db.read_meta_from_spreadsheet(cur_test, filename)
+      rc["meta"] = read_meta_from_spreadsheet(cur_test, filename)
 
       # We've already checked and warned about duplicate tests above, so we just use the first element here
       rc["objname"] = f"{filename}_0"
       meta = rc["meta"][rc["objname"]]
-      db.validate_meta(meta)
+      validate_meta(meta)
       meta["SiteName"] = rc["sitename"]
 
       # Build MVM paths and skip user requested files

--- a/python/compare.py
+++ b/python/compare.py
@@ -101,7 +101,7 @@ if __name__ == "__main__":
   elif args.db_google_id_1 == default_db_google_id:
     print ("Using the default metadata spreadsheet for the first dataset")
   else:
-    print (f"Using the metadata spreadsheet {args.db_google_id_1} for the first dataset")
+    print (f"Using metadata spreadsheet ID {args.db_google_id_1} for the first dataset")
 
   if args.cnaf_2:
     args.db_google_id_2 = cnaf_db_google_id
@@ -109,7 +109,7 @@ if __name__ == "__main__":
   elif args.db_google_id_2 == default_db_google_id:
     print ("Using the default metadata spreadsheet for the second dataset")
   else:
-    print (f"Using the metadata spreadsheet {args.db_google_id_2} for the second dataset")
+    print (f"Using metadata spreadsheet ID {args.db_google_id_2} for the second dataset")
 
   run_config = [
       {

--- a/python/compare.py
+++ b/python/compare.py
@@ -84,6 +84,8 @@ if __name__ == "__main__":
   parser.add_argument("--offset-2", type=float, help="Time offset between second vent and sim datasets.", default=0.)
   parser.add_argument("--pressure-offset-1", type=float, help="Pressure offset for first MVM dataset.", default=0.)
   parser.add_argument("--pressure-offset-2", type=float, help="Pressure offset for second MVM dataset.", default=0.)
+  parser.add_argument("--cnaf-1", action='store_true', help="overrides db-google-id to use the CNAF spreadsheet for the first dataset")
+  parser.add_argument("--cnaf-2", action='store_true', help="overrides db-google-id to use the CNAF spreadsheet for the second dataset")
   parser.add_argument("--db-google-id-1", help="First datset metadata spreadsheet ID.", default="1aQjGTREc9e7ScwrTQEqHD2gmRy9LhDiVatWznZJdlqM")
   parser.add_argument("--db-google-id-2", help="Second datset metadata spreadsheet ID.", default="1aQjGTREc9e7ScwrTQEqHD2gmRy9LhDiVatWznZJdlqM")
   parser.add_argument("--mvm-sep-1", help="Separator between datetime and the rest in the first MVM file", default="->")
@@ -91,6 +93,13 @@ if __name__ == "__main__":
   parser.add_argument("--mvm-col-1", help="Columns configuration for first MVM acquisition, see mvmio.py", default="mvm_col_arduino")
   parser.add_argument("--mvm-col-2", help="Columns configuration for second MVM acquisition, see mvmio.py", default="mvm_col_arduino")
   args = parser.parse_args()
+
+  if args.cnaf_1:
+    args.db_google_id_1 = "1AQXgqCKNAuCCDGffi9QU_v_9tOP97qYQNyxx9L6pWRA"
+    print ("Using the CNAF metadata spreadsheet for the first dataset")
+  if args.cnaf_2:
+    args.db_google_id_2 = "1AQXgqCKNAuCCDGffi9QU_v_9tOP97qYQNyxx9L6pWRA"
+    print ("Using the CNAF metadata spreadsheet for the second dataset")
 
   run_config = [
       {

--- a/python/mvmconstants.py
+++ b/python/mvmconstants.py
@@ -1,4 +1,7 @@
 
+default_db_google_id = "1aQjGTREc9e7ScwrTQEqHD2gmRy9LhDiVatWznZJdlqM"
+cnaf_db_google_id = "1AQXgqCKNAuCCDGffi9QU_v_9tOP97qYQNyxx9L6pWRA"
+
 class Ventilator:
   '''
   Constants about ventilators: specifications, etc.


### PR DESCRIPTION
Implemented easier `--cnaf` command line option to override the default db-google-id
(which is still in use, and should remain as default for backward compatibility)

Moved the actual google id strings to mvmconstants.py